### PR TITLE
Make optional default for schema match connector sdk ui

### DIFF
--- a/lib/workato/connector/sdk/schema.rb
+++ b/lib/workato/connector/sdk/schema.rb
@@ -144,7 +144,7 @@ module Workato
           if (parse_output = field.delete(:convert_output) || field[:parse_output])
             field[:parse_output] = parse_output.is_a?(Proc) ? nil : parse_output
           end
-          field[:optional] = true unless field.key?(:optional)
+          field[:optional] = false unless field.key?(:optional)
           field[:label] ||= field[:name].labelize
 
           clean_values(field)

--- a/spec/fixtures/connectors/echo.rb
+++ b/spec/fixtures/connectors/echo.rb
@@ -112,17 +112,17 @@
 
       input_fields: lambda do |_object_definitions, _connection, _config_fields|
         [
-          { name: :input, type: :boolean }
+          { name: :input, type: :number, optional: true }
         ]
       end,
 
       output_fields: lambda do |_object_definitions, _connection, _config_fields|
         [
-          { name: :input, type: :object },
-          { name: :connection, type: :object },
-          { name: :input_schema, type: :object },
-          { name: :output_schema, type: :object },
-          { name: :continue, type: :object }
+          { name: :input, type: :object, optional: true },
+          { name: :connection, type: :object, optional: true },
+          { name: :input_schema, type: :object, optional: true },
+          { name: :output_schema, type: :object, optional: true },
+          { name: :continue, type: :object, optional: true }
         ]
       end
     },
@@ -198,20 +198,20 @@
 
       input_fields: lambda do |_object_definitions, _connection, _config_fields|
         [
-          { name: :input, type: :boolean }
+          { name: :input, type: :number, optional: true  }
         ]
       end,
 
       output_fields: lambda do |_object_definitions, _connection, _config_fields|
         [
-          { name: :input, type: :object },
-          { name: :payload, type: :object },
-          { name: :extended_input_schema, type: :object },
-          { name: :extended_output_schema, type: :object },
-          { name: :headers, type: :object },
-          { name: :params, type: :object },
-          { name: :connection, type: :object },
-          { name: :webhook_subscribe_output, type: :object }
+          { name: :input, type: :object, optional: true  },
+          { name: :payload, type: :object, optional: true },
+          { name: :extended_input_schema, type: :object, optional: true },
+          { name: :extended_output_schema, type: :object, optional: true },
+          { name: :headers, type: :object, optional: true },
+          { name: :params, type: :object, optional: true },
+          { name: :connection, type: :object, optional: true },
+          { name: :webhook_subscribe_output, type: :object, optional: true }
         ]
       end
     },
@@ -231,15 +231,15 @@
 
       input_fields: lambda do |_object_definitions, _connection, _config_fields|
         [
-          { name: :input, type: :boolean }
+          { name: :input, type: :number, optional: true }
         ]
       end,
 
       output_fields: lambda do |_object_definitions, _connection, _config_fields|
         [
-          { name: :connection, type: :object },
-          { name: :input, type: :object },
-          { name: :closure, type: :object }
+          { name: :connection, type: :object, optional: true },
+          { name: :input, type: :object, optional: true },
+          { name: :closure, type: :object, optional: true }
         ]
       end
     }

--- a/spec/workato/connector/sdk/schema_spec.rb
+++ b/spec/workato/connector/sdk/schema_spec.rb
@@ -4,20 +4,21 @@ module Workato::Connector::Sdk
   RSpec.describe Schema do
     subject(:schema) { described_class.new(schema: properties) }
 
-    let(:int_field) { { name: :int_field, type: :integer, optional: false } }
-    let(:float_field) { { name: 'float_field', type: 'number' } }
-    let(:boolean_field) { { 'name' => :boolean_field, 'type' => :boolean } }
-    let(:date_field) { { name: :date_field, type: :date } }
-    let(:date_time_field) { { name: :date_time_field, type: :date_time } }
-    let(:timestamp_time_field) { { name: :timestamp_time_field, type: :timestamp } }
-    let(:string_field) { { name: :string_field } }
+    let(:int_field) { { name: :int_field, type: :integer} }
+    let(:float_field) { { name: 'float_field', type: 'number', optional: true } }
+    let(:boolean_field) { { 'name' => :boolean_field, 'type' => :boolean, optional: true } }
+    let(:date_field) { { name: :date_field, type: :date, optional: true } }
+    let(:date_time_field) { { name: :date_time_field, type: :date_time, optional: true } }
+    let(:timestamp_time_field) { { name: :timestamp_time_field, type: :timestamp, optional: true } }
+    let(:string_field) { { name: :string_field, optional: true } }
 
-    let(:array_of_int_field) { { name: :array_of_int_field, type: :array, of: :integer } }
+    let(:array_of_int_field) { { name: :array_of_int_field, type: :array, of: :integer, optional: true } }
     let(:array_of_objects_field) do
       {
         name: :array_of_objects_field, type: :array,
+        optional: true,
         properties: [
-          { name: :field1 }
+          { name: :field1, optional: true }
         ]
       }
     end
@@ -25,8 +26,9 @@ module Workato::Connector::Sdk
     let(:object_field) do
       {
         name: :object_field, type: :object,
+        optional: true,
         properties: [
-          { name: :prop1 }
+          { name: :prop1, optional: true }
         ]
       }
     end
@@ -34,6 +36,7 @@ module Workato::Connector::Sdk
     let(:with_toggle_field) do
       {
         name: :with_toggle_field, type: :integer, toggle_hint: 'toggle_hint',
+        optional: true,
         toggle_field: {
           name: :toggle_field,
           type: 'number'
@@ -46,6 +49,7 @@ module Workato::Connector::Sdk
         name: :with_overridden_attributes,
         type: :integer,
         control_type: :date_time,
+        optional: true,
         label: 'with_overridden_attributes',
         toggle_hint: 'toggle_hint',
         toggle_field: {


### PR DESCRIPTION
Connector SDK in the ui expects that when optional key is omitted, it defaults to false.
The sdk gem had the opposite functionality, causing tests relying on the gem to fail.