### PR TITLE
[PLAT-5666] Preparing for Rails 8.0 upgrade

### DIFF
--- a/lib/workato/connector/sdk/dsl/csv_package.rb
+++ b/lib/workato/connector/sdk/dsl/csv_package.rb
@@ -21,7 +21,7 @@ module Workato
 
         sig { params(size: Integer, max: Integer).void }
         def initialize(size, max)
-          super("CSV file is too big. Max allowed: #{max.to_s(:human_size)}, got: #{size.to_s(:human_size)}")
+          super("CSV file is too big. Max allowed: #{max.to_fs(:human_size)}, got: #{size.to_fs(:human_size)}")
           @size = T.let(size, Integer)
           @max = T.let(max, Integer)
         end

--- a/workato-connector-sdk.gemspec
+++ b/workato-connector-sdk.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.6'
 
-  spec.add_dependency 'activesupport', '>= 5.2', '< 7.1'
+  spec.add_dependency 'activesupport', '>= 5.2', '< 8.1'
   spec.add_dependency 'aws-sigv4', '~> 1.2', '>= 1.2.4'
   spec.add_dependency 'bundler', '~> 2.0'
   spec.add_dependency 'charlock_holmes', '~> 0.7', '>= 0.7.7'


### PR DESCRIPTION
Closes https://workato.atlassian.net/browse/PLAT-5666

- [x] We need to relax requirements for ActiveSupport
- [ ] Backport removed `to_s` in favor of `to_fs`
- [ ] Backport removed `sum` in favor of native Ruby implementation 